### PR TITLE
Reduce Docker memory limits for Oracle free tier (956MB RAM)

### DIFF
--- a/dmz/docker-compose.yml
+++ b/dmz/docker-compose.yml
@@ -50,9 +50,9 @@ services:
     deploy:
       resources:
         limits:
-          memory: 256M
-        reservations:
           memory: 128M
+        reservations:
+          memory: 64M
     logging:
       driver: "json-file"
       options:
@@ -380,9 +380,9 @@ services:
     deploy:
       resources:
         limits:
-          memory: 512M
+          memory: 256M
         reservations:
-          memory: 128M
+          memory: 64M
     logging:
       driver: "json-file"
       options:
@@ -411,9 +411,9 @@ services:
     deploy:
       resources:
         limits:
-          memory: 128M
-        reservations:
           memory: 64M
+        reservations:
+          memory: 32M
     logging:
       driver: "json-file"
       options:
@@ -541,9 +541,9 @@ services:
     deploy:
       resources:
         limits:
-          memory: 512M
-        reservations:
           memory: 256M
+        reservations:
+          memory: 128M
     logging:
       driver: "json-file"
       options:
@@ -592,9 +592,9 @@ services:
     deploy:
       resources:
         limits:
-          memory: 512M
-        reservations:
           memory: 256M
+        reservations:
+          memory: 128M
     logging:
       driver: "json-file"
       options:
@@ -626,9 +626,9 @@ services:
     deploy:
       resources:
         limits:
-          memory: 256M
-        reservations:
           memory: 128M
+        reservations:
+          memory: 64M
     logging:
       driver: "json-file"
       options:
@@ -674,9 +674,9 @@ services:
     deploy:
       resources:
         limits:
-          memory: 128M
-        reservations:
           memory: 64M
+        reservations:
+          memory: 32M
     logging:
       driver: "json-file"
       options:
@@ -685,7 +685,7 @@ services:
 
 ####################################################################################################
 
-  bentopdf:
+  bentopdf: #https://github.com/alam00000/bentopdf/blob/main/SIMPLE_MODE.md
     image: bentopdf/bentopdf-simple:latest
     container_name: bentopdf
     restart: unless-stopped
@@ -722,16 +722,16 @@ services:
     deploy:
       resources:
         limits:
-          memory: 512M
-        reservations:
           memory: 256M
+        reservations:
+          memory: 128M
     logging:
       driver: "json-file"
       options:
         max-size: "1m"
         max-file: "2"
 
-####################################################################################################        
+####################################################################################################
 
 networks:
   proxy:


### PR DESCRIPTION
## Problem
VPS was freezing due to memory over-allocation. Container limits totaled ~2.8GB but system only has 956MB RAM available, causing:
- System load of 32+ (should be < 1.0)
- 85% I/O wait from memory thrashing
- Docker health checks timing out
- Complete system unresponsiveness

## Changes
Reduced all container memory limits to realistic values:
- traefik: 256M → 128M (reservations: 128M → 64M)
- forgejo: 512M → 256M (reservations: 128M → 64M)
- forgejo-cache: 128M → 64M (reservations: 64M → 32M)
- uptime-kuma: 512M → 256M (reservations: 256M → 128M)
- searxng: 512M → 256M (reservations: 256M → 128M)
- searxng-redis: 256M → 128M (reservations: 128M → 64M)
- capture: 128M → 64M (reservations: 64M → 32M)
- bentopdf: 512M → 256M (reservations: 256M → 128M)

New total: ~1.4GB limits, ~640MB reservations (fits in 956MB with margin)

## Additional fixes applied to VPS
- Added 2GB swap space to handle memory pressure
- Disabled apt-daily timers to prevent resource-heavy background processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)