### PR TITLE
fix(forgejo): Add SYS_CHROOT capability for SSH authentication

### DIFF
--- a/dmz/docker-compose.yml
+++ b/dmz/docker-compose.yml
@@ -331,6 +331,7 @@ services:
       - SETGID
       - SETUID
       - DAC_OVERRIDE
+      - SYS_CHROOT
     environment:
       - APP_NAME="Forgejo"
       - USER_UID=1000


### PR DESCRIPTION
## Problem
Forgejo SSH authentication was failing with:
```
chroot("/var/empty"): Operation not permitted [preauth]
```

The container was missing the `SYS_CHROOT` capability that SSH requires to chroot to `/var/empty` during authentication.

## Solution
Added `CAP_SYS_CHROOT` to the forgejo service capabilities in `dmz/docker-compose.yml`.

## Testing
- ✅ Fixed on DMZ server (deployed and tested)
- ✅ SSH authentication now works: `ssh -T -p 222 git@129.146.141.62`
- ✅ Successfully authenticated with Voyager key

## Changes
- Added `- SYS_CHROOT` to forgejo service `cap_add` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)