### PR TITLE
Add Pi-hole Docker Compose for DS9 and Defiant

### DIFF
--- a/defiant/.env.example
+++ b/defiant/.env.example
@@ -1,0 +1,15 @@
+# Pi-hole Defiant Configuration
+# Copy this file to .env and fill in with actual values from Ansible vault
+
+# Pi-hole Web Interface Password (hashed)
+# This should come from Ansible vault variable: vault_pihole_webpassword
+# Original password is hashed with: echo -n 'password' | sha256sum | awk '{print $1}'
+PIHOLE_WEBPASSWORD=your_hashed_password_here
+
+# Example of how to hash a password:
+# echo -n 'your_password' | sha256sum | awk '{print $1}'
+
+# Notes:
+# - All other configuration is in docker-compose.yml
+# - Whitelist/blacklist domains configured via Pi-hole web UI or custom scripts
+# - Custom DNS entries in etc-dnsmasq.d/03-dns-overrides.conf (created after first run)

--- a/defiant/.gitignore
+++ b/defiant/.gitignore
@@ -1,0 +1,9 @@
+# Environment files with secrets
+.env
+
+# Pi-hole data directories (created at runtime)
+etc-pihole/
+etc-dnsmasq.d/
+
+# Logs
+*.log

--- a/defiant/03-dns-overrides.conf
+++ b/defiant/03-dns-overrides.conf
@@ -3,7 +3,7 @@
 # Format: address=/domain.name/ip.address
 
 # Dev server
-address=/voyager.internal.homelab.gg/192.168.9.103
+address=/voyager.internal.homelab.gg/192.168.9.2
 
 # pfSense router
 address=/pfsense.internal.homelab.gg/192.168.3.1

--- a/defiant/03-dns-overrides.conf
+++ b/defiant/03-dns-overrides.conf
@@ -1,0 +1,18 @@
+# Custom DNS Overrides for Pi-hole Defiant
+# This file defines custom DNS records for internal homelab services
+# Format: address=/domain.name/ip.address
+
+# Dev server
+address=/voyager.internal.homelab.gg/192.168.9.103
+
+# pfSense router
+address=/pfsense.internal.homelab.gg/192.168.3.1
+
+# Discovery server
+address=/discovery.internal.homelab.gg/192.168.9.9
+
+# Borg backup server
+address=/borg.internal.homelab.gg/192.168.9.7
+
+# K3s cluster
+address=/k3s-cluster.local/192.168.9.124

--- a/defiant/README.md
+++ b/defiant/README.md
@@ -1,0 +1,150 @@
+# Pi-hole Defiant
+
+DNS server with ad-blocking for homelab network (redundant pair with DS9).
+
+## Quick Start
+
+### 1. Create .env file from example
+
+```bash
+cp .env.example .env
+```
+
+### 2. Set Pi-hole password
+
+The password should come from Ansible vault variable `vault_pihole_webpassword`.
+
+If setting manually, generate hashed password:
+```bash
+echo -n 'your_password' | sha256sum | awk '{print $1}'
+```
+
+Add to `.env`:
+```
+PIHOLE_WEBPASSWORD=your_hashed_password_here
+```
+
+### 3. Deploy Pi-hole
+
+```bash
+docker-compose up -d
+```
+
+### 4. Configure custom DNS entries (Optional)
+
+After first startup, copy the custom DNS configuration:
+```bash
+cp custom-dns-overrides.conf.example etc-dnsmasq.d/03-dns-overrides.conf
+```
+
+Edit the file to match your homelab IPs, then restart:
+```bash
+docker-compose restart
+```
+
+### 5. Access Web Interface
+
+```
+http://<server-ip>/admin
+```
+
+Login with the password from your .env file (unhashed version).
+
+## Configuration
+
+### Whitelist Domains
+
+From Pi-hole web UI:
+- Settings → Whitelist
+- Add: dartsearch.net, googleadservices.com, clickserve.dartsearch.net, ad.doubleclick.net, ally.com, protonmail.com, loftliving.com, claude.ai
+
+Or via CLI:
+```bash
+docker exec pihole-defiant pihole -w dartsearch.net googleadservices.com clickserve.dartsearch.net ad.doubleclick.net ally.com protonmail.com loftliving.com claude.ai
+```
+
+### Blacklist Domains
+
+From Pi-hole web UI:
+- Settings → Blacklist
+- Add: app-analytics-v2.snapchat.com, metrics.icloud.com, metrics.plex.tv, analytics.plex.tv
+
+Or via CLI:
+```bash
+docker exec pihole-defiant pihole -b app-analytics-v2.snapchat.com metrics.icloud.com metrics.plex.tv analytics.plex.tv
+```
+
+## Gravity-Sync
+
+To sync block lists between DS9 and Defiant, gravity-sync can be configured separately.
+
+## Ansible Deployment
+
+This configuration matches the `deploy_pihole` Ansible role settings.
+
+Secrets are managed in Ansible vault:
+- `vault_pihole_webpassword` - Web interface password (hashed)
+
+## Networking
+
+- **DNS (TCP/UDP):** Port 53
+- **Web Interface (HTTP):** Port 80
+- **Web Interface (HTTPS):** Port 443 (optional, commented out by default)
+
+## Volumes
+
+- `./etc-pihole` - Pi-hole configuration and gravity database
+- `./etc-dnsmasq.d` - DNSMasq configuration (custom DNS entries)
+
+## Monitoring
+
+Add to Uptime Kuma:
+- **Type:** DNS
+- **Hostname:** defiant.internal.homelab.gg
+- **Port:** 53
+- **Record Type:** A
+- **Query:** google.com
+
+## Logs
+
+```bash
+# Follow logs
+docker logs -f pihole-defiant
+
+# Check query log
+docker exec pihole-defiant pihole -t
+```
+
+## Troubleshooting
+
+### DNS not resolving
+
+Check container is running:
+```bash
+docker ps | grep pihole-defiant
+```
+
+Check DNS is responding:
+```bash
+dig @<server-ip> google.com
+```
+
+### Can't access web interface
+
+Check port 80 is not in use:
+```bash
+sudo netstat -tulpn | grep :80
+```
+
+### Reset password
+
+```bash
+docker exec -it pihole-defiant pihole -a -p
+```
+
+## Server Information
+
+- **Hostname:** defiant
+- **Server IP:** 192.168.9.4 (expected)
+- **Upstream DNS:** 192.168.3.1 (pfSense)
+- **Paired with:** DS9 (192.168.9.3) for redundancy

--- a/defiant/blacklist.txt
+++ b/defiant/blacklist.txt
@@ -1,0 +1,8 @@
+# Pi-hole Blacklist
+# One domain per line
+# Lines starting with # are ignored
+
+app-analytics-v2.snapchat.com
+metrics.icloud.com
+metrics.plex.tv
+analytics.plex.tv

--- a/defiant/custom-dns-overrides.conf.example
+++ b/defiant/custom-dns-overrides.conf.example
@@ -1,0 +1,23 @@
+# Custom DNS Overrides for Pi-hole
+# Copy this file to etc-dnsmasq.d/03-dns-overrides.conf after first container startup
+#
+# This file defines custom DNS records for internal homelab services
+# Format: address=/domain.name/ip.address
+
+# Dev server
+address=/voyager.internal.homelab.gg/192.168.9.103
+
+# pfSense router
+address=/pfsense.internal.homelab.gg/192.168.3.1
+
+# Discovery server
+address=/discovery.internal.homelab.gg/192.168.9.9
+
+# Borg backup server
+address=/borg.internal.homelab.gg/192.168.9.7
+
+# K3s cluster
+address=/k3s-cluster.local/192.168.9.124
+
+# Add additional custom DNS entries below
+# address=/myservice.internal.homelab.gg/192.168.9.X

--- a/defiant/custom-dns-overrides.conf.example
+++ b/defiant/custom-dns-overrides.conf.example
@@ -5,7 +5,7 @@
 # Format: address=/domain.name/ip.address
 
 # Dev server
-address=/voyager.internal.homelab.gg/192.168.9.103
+address=/voyager.internal.homelab.gg/192.168.9.2
 
 # pfSense router
 address=/pfsense.internal.homelab.gg/192.168.3.1

--- a/defiant/docker-compose.yml
+++ b/defiant/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       REV_SERVER: 'true'
       REV_SERVER_CIDR: '192.168.3.0/24'
       REV_SERVER_TARGET: '192.168.3.1'
-      REV_SERVER_DOMAIN: 'pfsense.localdomain'
+      REV_SERVER_DOMAIN: 'pfsense.internal.homelab.gg'
 
       # Query logging
       QUERY_LOGGING: 'true'

--- a/defiant/docker-compose.yml
+++ b/defiant/docker-compose.yml
@@ -57,6 +57,8 @@ services:
       # Persistent configuration
       - './etc-pihole:/etc/pihole'
       - './etc-dnsmasq.d:/etc/dnsmasq.d'
+      # Custom DNS overrides (bind mount for immediate availability)
+      - './03-dns-overrides.conf:/etc/dnsmasq.d/03-dns-overrides.conf:ro'
 
     dns:
       # Use localhost for DNS resolution during startup

--- a/defiant/docker-compose.yml
+++ b/defiant/docker-compose.yml
@@ -1,0 +1,86 @@
+version: '3.8'
+
+services:
+  pihole:
+    container_name: pihole-defiant
+    image: pihole/pihole:latest
+    hostname: defiant
+    ports:
+      - "53:53/tcp"      # DNS TCP
+      - "53:53/udp"      # DNS UDP
+      - "80:80/tcp"      # Web interface (HTTP)
+      # - "443:443/tcp"  # Web interface (HTTPS) - uncomment if needed
+    environment:
+      # Timezone
+      TZ: 'America/Chicago'
+
+      # Web password (hashed - set in .env)
+      WEBPASSWORD: '${PIHOLE_WEBPASSWORD}'
+
+      # Upstream DNS servers (pfSense)
+      PIHOLE_DNS_: '192.168.3.1'
+
+      # DNSSEC validation
+      DNSSEC: 'true'
+
+      # DNS settings
+      DNSMASQ_LISTENING: 'single'
+      DNS_FQDN_REQUIRED: 'true'
+      DNS_BOGUS_PRIV: 'true'
+
+      # Reverse DNS server settings
+      REV_SERVER: 'true'
+      REV_SERVER_CIDR: '192.168.3.0/24'
+      REV_SERVER_TARGET: '192.168.3.1'
+      REV_SERVER_DOMAIN: 'pfsense.localdomain'
+
+      # Query logging
+      QUERY_LOGGING: 'true'
+
+      # Web interface
+      INSTALL_WEB_SERVER: 'true'
+      INSTALL_WEB_INTERFACE: 'true'
+
+      # Cache size
+      FTLCONF_MAXDBDAYS: '10000'
+
+      # Interface (container uses eth0 by default)
+      INTERFACE: 'eth0'
+
+      # Virtual host (optional)
+      VIRTUAL_HOST: 'defiant.internal.homelab.gg'
+
+      # IPv6 (disabled if not using)
+      IPv6: 'false'
+
+    volumes:
+      # Persistent configuration
+      - './etc-pihole:/etc/pihole'
+      - './etc-dnsmasq.d:/etc/dnsmasq.d'
+
+    dns:
+      # Use localhost for DNS resolution during startup
+      - 127.0.0.1
+      - 192.168.3.1
+
+    restart: unless-stopped
+
+    cap_drop:
+      - ALL
+
+    cap_add:
+      - NET_ADMIN      # Required for DHCP and network operations
+      - NET_BIND_SERVICE  # Required to bind to privileged ports (53, 80)
+      - NET_RAW        # Required for DHCP
+      - CHOWN          # Required for file ownership changes
+      - DAC_OVERRIDE   # Required for file permission overrides
+
+    security_opt:
+      - no-new-privileges:true
+
+    networks:
+      - pihole_network
+
+networks:
+  pihole_network:
+    driver: bridge

--- a/defiant/whitelist.txt
+++ b/defiant/whitelist.txt
@@ -1,0 +1,14 @@
+# Pi-hole Whitelist
+# One domain per line
+# Lines starting with # are ignored
+
+dartsearch.net
+googleadservices.com
+www.dartsearch.net
+www.googleadservices.com
+clickserve.dartsearch.net
+ad.doubleclick.net
+ally.com
+protonmail.com
+loftliving.com
+claude.ai

--- a/ds9/.env.example
+++ b/ds9/.env.example
@@ -1,0 +1,15 @@
+# Pi-hole DS9 Configuration
+# Copy this file to .env and fill in with actual values from Ansible vault
+
+# Pi-hole Web Interface Password (hashed)
+# This should come from Ansible vault variable: vault_pihole_webpassword
+# Original password is hashed with: echo -n 'password' | sha256sum | awk '{print $1}'
+PIHOLE_WEBPASSWORD=your_hashed_password_here
+
+# Example of how to hash a password:
+# echo -n 'your_password' | sha256sum | awk '{print $1}'
+
+# Notes:
+# - All other configuration is in docker-compose.yml
+# - Whitelist/blacklist domains configured via Pi-hole web UI or custom scripts
+# - Custom DNS entries in etc-dnsmasq.d/03-dns-overrides.conf (created after first run)

--- a/ds9/.gitignore
+++ b/ds9/.gitignore
@@ -1,0 +1,9 @@
+# Environment files with secrets
+.env
+
+# Pi-hole data directories (created at runtime)
+etc-pihole/
+etc-dnsmasq.d/
+
+# Logs
+*.log

--- a/ds9/03-dns-overrides.conf
+++ b/ds9/03-dns-overrides.conf
@@ -3,7 +3,7 @@
 # Format: address=/domain.name/ip.address
 
 # Dev server
-address=/voyager.internal.homelab.gg/192.168.9.103
+address=/voyager.internal.homelab.gg/192.168.9.2
 
 # pfSense router
 address=/pfsense.internal.homelab.gg/192.168.3.1

--- a/ds9/03-dns-overrides.conf
+++ b/ds9/03-dns-overrides.conf
@@ -1,0 +1,18 @@
+# Custom DNS Overrides for Pi-hole DS9
+# This file defines custom DNS records for internal homelab services
+# Format: address=/domain.name/ip.address
+
+# Dev server
+address=/voyager.internal.homelab.gg/192.168.9.103
+
+# pfSense router
+address=/pfsense.internal.homelab.gg/192.168.3.1
+
+# Discovery server
+address=/discovery.internal.homelab.gg/192.168.9.9
+
+# Borg backup server
+address=/borg.internal.homelab.gg/192.168.9.7
+
+# K3s cluster
+address=/k3s-cluster.local/192.168.9.124

--- a/ds9/README.md
+++ b/ds9/README.md
@@ -1,0 +1,150 @@
+# Pi-hole DS9
+
+DNS server with ad-blocking for homelab network.
+
+## Quick Start
+
+### 1. Create .env file from example
+
+```bash
+cp .env.example .env
+```
+
+### 2. Set Pi-hole password
+
+The password should come from Ansible vault variable `vault_pihole_webpassword`.
+
+If setting manually, generate hashed password:
+```bash
+echo -n 'your_password' | sha256sum | awk '{print $1}'
+```
+
+Add to `.env`:
+```
+PIHOLE_WEBPASSWORD=your_hashed_password_here
+```
+
+### 3. Deploy Pi-hole
+
+```bash
+docker-compose up -d
+```
+
+### 4. Configure custom DNS entries (Optional)
+
+After first startup, copy the custom DNS configuration:
+```bash
+cp custom-dns-overrides.conf.example etc-dnsmasq.d/03-dns-overrides.conf
+```
+
+Edit the file to match your homelab IPs, then restart:
+```bash
+docker-compose restart
+```
+
+### 5. Access Web Interface
+
+```
+http://<server-ip>/admin
+```
+
+Login with the password from your .env file (unhashed version).
+
+## Configuration
+
+### Whitelist Domains
+
+From Pi-hole web UI:
+- Settings → Whitelist
+- Add: dartsearch.net, googleadservices.com, clickserve.dartsearch.net, ad.doubleclick.net, ally.com, protonmail.com, loftliving.com, claude.ai
+
+Or via CLI:
+```bash
+docker exec pihole-ds9 pihole -w dartsearch.net googleadservices.com clickserve.dartsearch.net ad.doubleclick.net ally.com protonmail.com loftliving.com claude.ai
+```
+
+### Blacklist Domains
+
+From Pi-hole web UI:
+- Settings → Blacklist
+- Add: app-analytics-v2.snapchat.com, metrics.icloud.com, metrics.plex.tv, analytics.plex.tv
+
+Or via CLI:
+```bash
+docker exec pihole-ds9 pihole -b app-analytics-v2.snapchat.com metrics.icloud.com metrics.plex.tv analytics.plex.tv
+```
+
+## Gravity-Sync
+
+To sync block lists between DS9 and Defiant, gravity-sync can be configured separately.
+
+## Ansible Deployment
+
+This configuration matches the `deploy_pihole` Ansible role settings.
+
+Secrets are managed in Ansible vault:
+- `vault_pihole_webpassword` - Web interface password (hashed)
+
+## Networking
+
+- **DNS (TCP/UDP):** Port 53
+- **Web Interface (HTTP):** Port 80
+- **Web Interface (HTTPS):** Port 443 (optional, commented out by default)
+
+## Volumes
+
+- `./etc-pihole` - Pi-hole configuration and gravity database
+- `./etc-dnsmasq.d` - DNSMasq configuration (custom DNS entries)
+
+## Monitoring
+
+Add to Uptime Kuma:
+- **Type:** DNS
+- **Hostname:** ds9.internal.homelab.gg
+- **Port:** 53
+- **Record Type:** A
+- **Query:** google.com
+
+## Logs
+
+```bash
+# Follow logs
+docker logs -f pihole-ds9
+
+# Check query log
+docker exec pihole-ds9 pihole -t
+```
+
+## Troubleshooting
+
+### DNS not resolving
+
+Check container is running:
+```bash
+docker ps | grep pihole-ds9
+```
+
+Check DNS is responding:
+```bash
+dig @<server-ip> google.com
+```
+
+### Can't access web interface
+
+Check port 80 is not in use:
+```bash
+sudo netstat -tulpn | grep :80
+```
+
+### Reset password
+
+```bash
+docker exec -it pihole-ds9 pihole -a -p
+```
+
+## Server Information
+
+- **Hostname:** ds9
+- **Server IP:** 192.168.9.3 (expected)
+- **Upstream DNS:** 192.168.3.1 (pfSense)
+- **Paired with:** Defiant (192.168.9.4) for redundancy

--- a/ds9/blacklist.txt
+++ b/ds9/blacklist.txt
@@ -1,0 +1,8 @@
+# Pi-hole Blacklist
+# One domain per line
+# Lines starting with # are ignored
+
+app-analytics-v2.snapchat.com
+metrics.icloud.com
+metrics.plex.tv
+analytics.plex.tv

--- a/ds9/custom-dns-overrides.conf.example
+++ b/ds9/custom-dns-overrides.conf.example
@@ -1,0 +1,23 @@
+# Custom DNS Overrides for Pi-hole
+# Copy this file to etc-dnsmasq.d/03-dns-overrides.conf after first container startup
+#
+# This file defines custom DNS records for internal homelab services
+# Format: address=/domain.name/ip.address
+
+# Dev server
+address=/voyager.internal.homelab.gg/192.168.9.103
+
+# pfSense router
+address=/pfsense.internal.homelab.gg/192.168.3.1
+
+# Discovery server
+address=/discovery.internal.homelab.gg/192.168.9.9
+
+# Borg backup server
+address=/borg.internal.homelab.gg/192.168.9.7
+
+# K3s cluster
+address=/k3s-cluster.local/192.168.9.124
+
+# Add additional custom DNS entries below
+# address=/myservice.internal.homelab.gg/192.168.9.X

--- a/ds9/custom-dns-overrides.conf.example
+++ b/ds9/custom-dns-overrides.conf.example
@@ -5,7 +5,7 @@
 # Format: address=/domain.name/ip.address
 
 # Dev server
-address=/voyager.internal.homelab.gg/192.168.9.103
+address=/voyager.internal.homelab.gg/192.168.9.2
 
 # pfSense router
 address=/pfsense.internal.homelab.gg/192.168.3.1

--- a/ds9/docker-compose.yml
+++ b/ds9/docker-compose.yml
@@ -1,0 +1,86 @@
+version: '3.8'
+
+services:
+  pihole:
+    container_name: pihole-ds9
+    image: pihole/pihole:latest
+    hostname: ds9
+    ports:
+      - "53:53/tcp"      # DNS TCP
+      - "53:53/udp"      # DNS UDP
+      - "80:80/tcp"      # Web interface (HTTP)
+      # - "443:443/tcp"  # Web interface (HTTPS) - uncomment if needed
+    environment:
+      # Timezone
+      TZ: 'America/Chicago'
+
+      # Web password (hashed - set in .env)
+      WEBPASSWORD: '${PIHOLE_WEBPASSWORD}'
+
+      # Upstream DNS servers (pfSense)
+      PIHOLE_DNS_: '192.168.3.1'
+
+      # DNSSEC validation
+      DNSSEC: 'true'
+
+      # DNS settings
+      DNSMASQ_LISTENING: 'single'
+      DNS_FQDN_REQUIRED: 'true'
+      DNS_BOGUS_PRIV: 'true'
+
+      # Reverse DNS server settings
+      REV_SERVER: 'true'
+      REV_SERVER_CIDR: '192.168.3.0/24'
+      REV_SERVER_TARGET: '192.168.3.1'
+      REV_SERVER_DOMAIN: 'pfsense.localdomain'
+
+      # Query logging
+      QUERY_LOGGING: 'true'
+
+      # Web interface
+      INSTALL_WEB_SERVER: 'true'
+      INSTALL_WEB_INTERFACE: 'true'
+
+      # Cache size
+      FTLCONF_MAXDBDAYS: '10000'
+
+      # Interface (container uses eth0 by default)
+      INTERFACE: 'eth0'
+
+      # Virtual host (optional)
+      VIRTUAL_HOST: 'ds9.internal.homelab.gg'
+
+      # IPv6 (disabled if not using)
+      IPv6: 'false'
+
+    volumes:
+      # Persistent configuration
+      - './etc-pihole:/etc/pihole'
+      - './etc-dnsmasq.d:/etc/dnsmasq.d'
+
+    dns:
+      # Use localhost for DNS resolution during startup
+      - 127.0.0.1
+      - 192.168.3.1
+
+    restart: unless-stopped
+
+    cap_drop:
+      - ALL
+
+    cap_add:
+      - NET_ADMIN      # Required for DHCP and network operations
+      - NET_BIND_SERVICE  # Required to bind to privileged ports (53, 80)
+      - NET_RAW        # Required for DHCP
+      - CHOWN          # Required for file ownership changes
+      - DAC_OVERRIDE   # Required for file permission overrides
+
+    security_opt:
+      - no-new-privileges:true
+
+    networks:
+      - pihole_network
+
+networks:
+  pihole_network:
+    driver: bridge

--- a/ds9/docker-compose.yml
+++ b/ds9/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       REV_SERVER: 'true'
       REV_SERVER_CIDR: '192.168.3.0/24'
       REV_SERVER_TARGET: '192.168.3.1'
-      REV_SERVER_DOMAIN: 'pfsense.localdomain'
+      REV_SERVER_DOMAIN: 'pfsense.internal.homelab.gg'
 
       # Query logging
       QUERY_LOGGING: 'true'

--- a/ds9/docker-compose.yml
+++ b/ds9/docker-compose.yml
@@ -57,6 +57,8 @@ services:
       # Persistent configuration
       - './etc-pihole:/etc/pihole'
       - './etc-dnsmasq.d:/etc/dnsmasq.d'
+      # Custom DNS overrides (bind mount for immediate availability)
+      - './03-dns-overrides.conf:/etc/dnsmasq.d/03-dns-overrides.conf:ro'
 
     dns:
       # Use localhost for DNS resolution during startup

--- a/ds9/whitelist.txt
+++ b/ds9/whitelist.txt
@@ -1,0 +1,14 @@
+# Pi-hole Whitelist
+# One domain per line
+# Lines starting with # are ignored
+
+dartsearch.net
+googleadservices.com
+www.dartsearch.net
+www.googleadservices.com
+clickserve.dartsearch.net
+ad.doubleclick.net
+ally.com
+protonmail.com
+loftliving.com
+claude.ai


### PR DESCRIPTION
## Summary

Add Docker Compose Pi-hole deployments for DS9 and Defiant DNS servers with file-based whitelist/blacklist configuration and custom DNS overrides.

## Changes

### DS9 Directory
- **docker-compose.yml**: Pi-hole container configuration
  - Security: `cap_drop: ALL` + minimal `cap_add`
  - DNSSEC enabled
  - Upstream DNS: pfSense (192.168.3.1)
  - Custom DNS config mounted as read-only
- **03-dns-overrides.conf**: Internal homelab DNS entries
- **whitelist.txt**: 10 whitelisted domains
- **blacklist.txt**: 4 blacklisted domains
- **.env.example**: Template for Ansible vault secrets
- **.gitignore**: Excludes .env and runtime data
- **README.md**: Deployment and configuration guide

### Defiant Directory
- Same structure as DS9
- Hostname: defiant
- Container name: pihole-defiant

### Custom DNS Entries
Both servers include internal homelab DNS overrides:
- voyager.internal.homelab.gg → 192.168.9.103
- pfsense.internal.homelab.gg → 192.168.3.1
- discovery.internal.homelab.gg → 192.168.9.9
- borg.internal.homelab.gg → 192.168.9.7
- k3s-cluster.local → 192.168.9.124

## Configuration

### Whitelist (10 domains)
- dartsearch.net
- googleadservices.com
- clickserve.dartsearch.net
- ad.doubleclick.net
- ally.com
- protonmail.com
- loftliving.com
- claude.ai
- (and www. variants)

### Blacklist (4 domains)
- app-analytics-v2.snapchat.com
- metrics.icloud.com
- metrics.plex.tv
- analytics.plex.tv

## Ansible Integration

Works with `deploy_pihole` Ansible role:
- Role detects Docker deployment automatically
- Reads whitelist/blacklist from role files
- Applies configuration via `docker exec`
- Custom DNS handled by mounted config file

**Deployment order:**
1. Deploy docker-compose stack (this PR)
2. Run `deploy_pihole` role (auto-detects Docker)

## Security

✅ **Least privilege**: `cap_drop: ALL` before selective `cap_add`  
✅ **Read-only mounts**: Custom DNS config mounted as `:ro`  
✅ **No new privileges**: `security_opt: no-new-privileges:true`  
✅ **Secrets excluded**: `.gitignore` prevents .env commits

## Deployment

```bash
# DS9
cd ~/code_base/docker_projects/ds9
cp .env.example .env
# Fill in PIHOLE_WEBPASSWORD from vault
docker-compose up -d

# Defiant
cd ~/code_base/docker_projects/defiant
cp .env.example .env
# Fill in PIHOLE_WEBPASSWORD from vault
docker-compose up -d
```

## Expected Server IPs

- **DS9**: 192.168.9.3
- **Defiant**: 192.168.9.4

## Related PR

- ansible_projects: [feat/pihole-docker-support](https://github.com/KolinSmith/ansible_projects/pull/29)

🤖 Generated with Claude Code