### PR TITLE
Disable Traefik dashboard and reduce logging on DMZ server

### DIFF
--- a/dmz/docker-compose.yml
+++ b/dmz/docker-compose.yml
@@ -28,20 +28,8 @@ services:
       - /home/ubuntu/docker-data/traefik/data/acme.json:/acme-cloudflare.json
       - /home/ubuntu/docker-data/traefik/data/configurations:/configurations
     labels:
-      - "traefik.enable=true"
-      - "traefik.docker.network=proxy"
-      # Route for duckdns domain
-      - "traefik.http.routers.traefik-secure.entrypoints=websecure"
-      - "traefik.http.routers.traefik-secure.rule=Host(`traefik.${DUCKDNS_DOMAIN}`)"
-      - "traefik.http.routers.traefik-secure.tls.certresolver=duckdns"
-      - "traefik.http.routers.traefik-secure.service=api@internal"
-      - "traefik.http.routers.traefik-secure.middlewares=user-auth@file"
-      # Route for search domain
-      - "traefik.http.routers.traefik-searchdomain.entrypoints=websecure"
-      - "traefik.http.routers.traefik-searchdomain.rule=Host(`traefik.${SEARCH_DOMAIN}`)"
-      - "traefik.http.routers.traefik-searchdomain.tls.certresolver=cloudflare"
-      - "traefik.http.routers.traefik-searchdomain.service=api@internal"
-      - "traefik.http.routers.traefik-searchdomain.middlewares=user-auth@file"
+      # Dashboard disabled for security - no public management interface
+      - "traefik.enable=false"
     # healthcheck:
     #   test: ["CMD", "traefik", "healthcheck", "--ping"]
     #   interval: 10s

--- a/dmz/docker-data/traefik/traefik.yml
+++ b/dmz/docker-data/traefik/traefik.yml
@@ -1,6 +1,6 @@
 api:
-  dashboard: true
-  debug: true
+  dashboard: false
+  debug: false
 
 entryPoints:
   web:
@@ -25,7 +25,7 @@ serversTransport:
   insecureSkipVerify: true
 
 log:
-  level: DEBUG
+  level: WARN
 
 providers:
   docker:


### PR DESCRIPTION
## Summary

Security improvements for the internet-facing DMZ Traefik instance:

- **Disable Traefik dashboard** (`api.dashboard: false`) - removes public management interface
- **Disable API debug mode** (`api.debug: false`) - reduces information exposure
- **Change log level** from `DEBUG` to `WARN` - reduces verbosity and potential information leakage
- **Remove public dashboard routes** - no longer exposes `traefik.${DUCKDNS_DOMAIN}` or `traefik.${SEARCH_DOMAIN}`

## Security Issues Addressed

| Issue | Before | After |
|-------|--------|-------|
| Dashboard exposed | ⚠️ Public at `traefik.*` | ✅ Disabled |
| Weak auth (password: "test") | ⚠️ Accessible | ✅ Not exposed |
| Debug logging | ⚠️ Verbose (DEBUG) | ✅ Minimal (WARN) |
| Infrastructure visibility | ⚠️ Attackers can see topology | ✅ Hidden |

## Impact

- ✅ All application services (Forgejo, Uptime Kuma, SearXNG, BenToPDF) **unaffected**
- ✅ Traefik continues functioning as reverse proxy
- ✅ Certificate management (DNS challenge) **unaffected**
- ✅ No user-facing changes

## Test Plan

- [ ] Deploy to DMZ server: `docker-compose down && docker-compose up -d`
- [ ] Verify Traefik is running: `docker ps | grep traefik`
- [ ] Confirm dashboard is inaccessible: `curl -I https://traefik.${SEARCH_DOMAIN}` (expect 404)
- [ ] Verify services still work (Forgejo, Uptime Kuma, SearXNG, BenToPDF)
- [ ] Check log level: `docker logs traefik 2>&1 | head -20`

## Rollback

```bash
git checkout master
docker-compose down && docker-compose up -d
```

🤖 Generated with [Claude Code](https://claude.ai/code)