### PR TITLE
Replace capture with beszel-agent in operator stack

### DIFF
--- a/operator/.env.example
+++ b/operator/.env.example
@@ -1,23 +1,14 @@
 # Operator Docker Environment Variables
 # Copy to .env and customize
 
-# Capture API Secret (required)
-CAPTURE_API_SECRET=your-api-secret-here
+# Beszel Agent Key (required)
+# Get this from Beszel web UI when adding a new system
+BESZEL_AGENT_KEY=your-ssh-public-key-here
 
-# Tor Relay Configuration (optional - can also configure in torrc)
-# These values will override torrc settings if uncommented
+# Tor Relay Identity (required)
+TOR_NICKNAME=YourRelayNickname
+TOR_CONTACT_INFO=your-email@example.com
 
-# Relay identity
-#TOR_NICKNAME=YourRelayNickname
-#TOR_CONTACT_INFO=your-email@example.com
-
-# Ports (must match docker-compose.yml port mappings)
+# Tor Relay Ports (optional - defaults shown)
 #TOR_OR_PORT=8443
 #TOR_DIR_PORT=8444
-
-# Bandwidth limits (in KBytes)
-#TOR_RELAY_BANDWIDTH_RATE=1000
-#TOR_RELAY_BANDWIDTH_BURST=1500
-
-# Note: For full Tor configuration options, edit torrc directly
-# See: https://github.com/KolinSmith/tor-relay-docker

--- a/operator/README.md
+++ b/operator/README.md
@@ -1,18 +1,10 @@
 # Operator Services
 
-Docker Compose stack for the Operator server running:
-- **Capture** - System monitoring and capture tool
+Docker Compose stack for the Operator server (Orange Pi R1 Plus LTS) running:
 - **Tor Relay** - Tor middle relay / guard node
+- **Beszel Agent** - System monitoring agent
 
 ## Services
-
-### Capture
-Lightweight system monitoring service from Bluewave Labs.
-
-- **Image**: `ghcr.io/bluewave-labs/capture:latest`
-- **Port**: Uses host network mode
-- **Memory**: 128MB limit
-- **Config**: Requires `CAPTURE_API_SECRET` in `.env`
 
 ### Tor Relay
 Tor middle relay that may be promoted to Guard status after ~8 days of stable operation.
@@ -20,131 +12,93 @@ Tor middle relay that may be promoted to Guard status after ~8 days of stable op
 - **Image**: `ghcr.io/kolinsmith/tor-relay-docker:latest`
 - **Ports**: 8443 (ORPort), 8444 (DirPort)
 - **Memory**: 1GB limit, 512MB reserved
-- **Config**: Edit `torrc` to set relay nickname and contact info
+- **Config**: `torrc` file (already configured for operaTor relay)
 - **Docs**: https://github.com/KolinSmith/tor-relay-docker
+
+### Beszel Agent
+Lightweight system monitoring agent that reports to Beszel hub.
+
+- **Image**: `henrygd/beszel-agent:latest`
+- **Port**: 45876 (SSH for hub connection)
+- **Memory**: 128MB limit
+- **Config**: Requires `BESZEL_AGENT_KEY` in `.env`
 
 ## Quick Start
 
 ### Prerequisites
 - Docker and Docker Compose installed
 - Firewall ports 8443 and 8444 open (for Tor relay)
+- Beszel hub running and accessible
 
 ### Setup
 
 1. **Create environment file**:
    ```bash
    cp .env.example .env
-   # Edit .env and set CAPTURE_API_SECRET
+   # Edit .env and set BESZEL_AGENT_KEY from Beszel web UI
    ```
 
-2. **Configure Tor relay**:
+2. **Start services**:
    ```bash
-   # Edit torrc and set your relay nickname and contact email
-   nano torrc
+   docker compose up -d
    ```
 
-   **Required changes**:
-   - `Nickname YourRelayNickname` → Set your unique relay name
-   - `ContactInfo your-email@example.com` → Set your contact email
-
-3. **Start services**:
+3. **Check logs**:
    ```bash
-   docker-compose up -d
-   ```
-
-4. **Check logs**:
-   ```bash
-   # Capture logs
-   docker-compose logs -f capture
-
    # Tor relay logs
-   docker-compose logs -f tor-relay
+   docker compose logs -f tor-relay
+
+   # Beszel agent logs
+   docker compose logs -f beszel-agent
    ```
 
 ## Monitoring Tor Relay
 
-### Interactive Monitoring with Nyx
-
-Install nyx on the host:
-```bash
-sudo apt install nyx
-```
-
-Create an alias for easy monitoring:
-```bash
-# Add to ~/.bashrc or ~/.bash_aliases
-alias status='docker exec -it tor-relay sudo -u debian-tor nyx'
-```
-
-Then run: `status`
-
 ### Check Relay on Tor Network
 
 Visit [Tor Metrics Relay Search](https://metrics.torproject.org/rs.html#search) to find your relay:
-- Search by relay nickname
+- Search by nickname: `operaTor`
 - Search by contact email
-- Search by fingerprint
 
 **Note**: New relays appear within 24-48 hours. Guard promotion takes ~8 days of stable operation.
 
 ## Managing Services
 
-### View logs
 ```bash
-# All services
-docker-compose logs -f
+# View logs
+docker compose logs -f
 
-# Specific service
-docker-compose logs -f tor-relay
-docker-compose logs -f capture
+# Restart services
+docker compose restart
+
+# Stop services
+docker compose down
+
+# Update images
+docker compose pull
+docker compose up -d
 ```
-
-### Restart services
-```bash
-# All services
-docker-compose restart
-
-# Specific service
-docker-compose restart tor-relay
-```
-
-### Stop services
-```bash
-docker-compose down
-```
-
-### Update images
-```bash
-docker-compose pull
-docker-compose up -d
-```
-
-## Configuration
-
-### Capture
-- Set `CAPTURE_API_SECRET` in `.env` file
-- Memory limit: 128MB
-
-### Tor Relay
-- **Primary config**: Edit `torrc` file
-- **Optional env vars**: Can override torrc settings in `.env`
-- **Ports**: Customize via `TOR_OR_PORT` and `TOR_DIR_PORT` env vars
-- **Memory limit**: 1GB (sufficient for middle relay/guard)
-
-### Exit Relay Configuration
-If you want to run an exit relay instead of a middle relay, see the comprehensive guide:
-https://github.com/KolinSmith/tor-relay-docker#exit-relay-configuration
 
 ## Volumes
 
 - `tor_data` - Tor relay keys and state (preserve to maintain relay identity)
 - `tor_logs` - Tor log files
+- `beszel_agent_data` - Beszel agent data
 
 **Important**: The `tor_data` volume contains your relay's cryptographic identity. Do not delete this volume or your relay will lose its reputation and fingerprint.
+
+## Migration from Native Tor
+
+When migrating from native Tor installation to Docker:
+
+1. Stop native Tor: `sudo systemctl stop tor`
+2. Copy identity keys from `/var/lib/tor/` to the `tor_data` volume
+3. Disable native Tor: `sudo systemctl disable tor`
+4. Start Docker stack: `docker compose up -d`
 
 ## Resources
 
 - **Tor Relay Guide**: https://community.torproject.org/relay/
 - **Tor Metrics**: https://metrics.torproject.org/
-- **Capture Project**: https://github.com/bluewave-labs/capture
+- **Beszel**: https://github.com/henrygd/beszel
 - **Tor Relay Docker**: https://github.com/KolinSmith/tor-relay-docker

--- a/operator/docker-compose.yml
+++ b/operator/docker-compose.yml
@@ -1,9 +1,16 @@
 services:
-  capture:
-    image: ghcr.io/bluewave-labs/capture:latest
-    container_name: capture
+  beszel-agent:
+    image: henrygd/beszel-agent:latest
+    container_name: beszel-agent
     restart: unless-stopped
     network_mode: host
+    environment:
+      PORT: 45876
+      KEY: "${BESZEL_AGENT_KEY}"
+    volumes:
+      - ./beszel_agent_data:/var/lib/beszel-agent
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /:/host:ro
     security_opt:
       - no-new-privileges:true
     cap_drop:
@@ -13,22 +20,8 @@ services:
       - SETGID
       - SETUID
       - DAC_OVERRIDE
-    env_file:
-      - .env
-    volumes:
-      - /etc/os-release:/etc/os-release:ro
-      - /etc/localtime:/etc/localtime:ro
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-    # labels:
-    #   - "traefik.enable=true"
-    #   - "traefik.docker.network=proxy"
-    #   # Route for search domain
-    #   - "traefik.http.routers.capture-searchdomain.entrypoints=websecure"
-    #   - "traefik.http.routers.capture-searchdomain.rule=Host(`capture.${SEARCH_DOMAIN}`)"
-    #   - "traefik.http.routers.capture-searchdomain.tls.certresolver=cloudflare"
-    #   - "traefik.http.routers.capture-searchdomain.service=capture-service"
-    #   # Service definition
-    #   - "traefik.http.services.capture-service.loadbalancer.server.port=59232"
+      - SYS_PTRACE
+      - NET_ADMIN
     deploy:
       resources:
         limits:

--- a/operator/torrc
+++ b/operator/torrc
@@ -1,7 +1,6 @@
 # Tor Relay Configuration
-# Example configuration - customize before deploying!
-# Default: Middle relay / Guard node (no exit traffic)
-# See https://github.com/KolinSmith/tor-relay-docker for exit relay configuration
+# Middle relay / Guard node (no exit traffic)
+# Nickname and ContactInfo are set via environment variables in .env
 
 # Disable SOCKS proxy (relay only, no local connections)
 SOCKSPort 0
@@ -27,7 +26,8 @@ CookieAuthentication 1
 ORPort 8443
 DirPort 8444
 
-# Relay identity (REQUIRED: Change these before deploying!)
+# Relay identity - Set via TOR_NICKNAME and TOR_CONTACT_INFO env vars
+# These placeholder values are overridden by environment variables
 Nickname YourRelayNickname
 ContactInfo your-email@example.com
 
@@ -37,7 +37,6 @@ RelayBandwidthRate 1000 KBytes
 RelayBandwidthBurst 1500 KBytes
 
 # Exit policy: Middle relay / Guard node (no exit traffic)
-# For exit relay configuration, see https://github.com/KolinSmith/tor-relay-docker README
 ExitPolicy reject *:*
 
 # Uncomment if running multiple relays (add fingerprints)


### PR DESCRIPTION
## Summary
- Replace capture monitoring service with beszel-agent for operator server
- Update torrc to use env vars for Nickname/ContactInfo (managed by Ansible)
- Update .env.example with BESZEL_AGENT_KEY and TOR_* variables
- Update README for new service configuration

## Changes
- `docker-compose.yml`: Swap capture for beszel-agent service
- `torrc`: Add comments noting env var configuration
- `.env.example`: New variables for beszel + tor identity
- `README.md`: Updated documentation

## Test plan
- [ ] Deploy to operator server after merging ansible_projects PR
- [ ] Verify beszel-agent connects to hub
- [ ] Verify Tor relay starts with correct identity

🤖 Generated with [Claude Code](https://claude.com/claude-code)