### PR TITLE
Fix Tor relay IPv6 warning by adding IPv4Only

### DIFF
--- a/operator/torrc
+++ b/operator/torrc
@@ -23,8 +23,8 @@ CookieAuthentication 1
 ############### Relay Configuration ###############
 
 # Relay ports
-ORPort 8443
-DirPort 8444
+ORPort 8443 IPv4Only
+DirPort 8444 IPv4Only
 
 # Relay identity - Set via TOR_NICKNAME and TOR_CONTACT_INFO env vars
 # These placeholder values are overridden by environment variables


### PR DESCRIPTION
## Summary
- Added `IPv4Only` flag to `ORPort 8443` and `DirPort 8444` in torrc configuration
- Resolves recurring Tor notices about unable to find IPv6 address

## Problem
The operator server's Tor relay logs were showing repeated notices:
```
Unable to find IPv6 address for ORPort 8443. You might want to specify 
IPv4Only to it or set an explicit address or set Address.
```

## Solution
Since the operator server doesn't have IPv6 configured, explicitly specify `IPv4Only` for both relay ports to suppress these warnings.

## Test plan
- [ ] Deploy updated torrc to operator server
- [ ] Restart tor-relay container
- [ ] Verify logs no longer show IPv6 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)