### PR TITLE
Pin forgejo-runner image to 12.6.3 (no latest tag exists)

### DIFF
--- a/forgejo-runner/docker-compose.yml
+++ b/forgejo-runner/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   forgejo-runner:
-    image: code.forgejo.org/forgejo/runner:latest
+    image: code.forgejo.org/forgejo/runner:12.6.3
     container_name: forgejo-runner
     restart: unless-stopped
     user: "1000:1000"  # Runner user (match host user)


### PR DESCRIPTION
## Summary

The registry at `code.forgejo.org` does not publish a `latest` tag for the runner image, which caused the pull to fail with "not found". Pinned to `12.6.3` (current latest release confirmed via registry tag list API).

The registry requires an anonymous bearer token to pull -- Docker handles this transparently once a valid versioned tag is specified.

## Test Plan

- [ ] Merge, re-run `deploy_docker_env` against forgejo-runner (to pick up updated docker-compose.yml), then `docker compose up -d`
- [ ] Verify container starts and registers with Forgejo

🤖 Generated with [Claude Code](https://claude.com/claude-code)