### PR TITLE
Add daemon command and beszel-agent to forgejo-runner

### DIFF
--- a/forgejo-runner/docker-compose.yml
+++ b/forgejo-runner/docker-compose.yml
@@ -1,7 +1,48 @@
 services:
+  beszel-agent:
+    image: henrygd/beszel-agent:latest
+    container_name: beszel-agent
+    restart: unless-stopped
+    user: "0:0"  # Must run as root for system monitoring
+    tty: false
+    stdin_open: false
+    network_mode: host
+    environment:
+      PORT: 45876
+      KEY: "${BESZEL_AGENT_KEY}"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /:/host:ro
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - CHOWN
+      - SETGID
+      - SETUID
+      - DAC_OVERRIDE
+      - SYS_PTRACE
+      - NET_ADMIN
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,nodev,size=128m
+    deploy:
+      resources:
+        limits:
+          memory: 128M
+          pids: 128
+        reservations:
+          memory: 64M
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "1m"
+        max-file: "1"
+
   forgejo-runner:
     image: code.forgejo.org/forgejo/runner:12.6.3
     container_name: forgejo-runner
+    command: daemon
     restart: unless-stopped
     user: "1000:1000"  # Runner user (match host user)
     tty: false

--- a/forgejo-runner/docker-compose.yml
+++ b/forgejo-runner/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     container_name: forgejo-runner
     command: /bin/forgejo-runner daemon
     restart: unless-stopped
-    user: "1000:1000"  # Runner user (match host user)
+    user: "1000:999"  # UID matches image default (owns /data), GID 999 = docker group for socket access
     tty: false
     stdin_open: false
     environment:

--- a/forgejo-runner/docker-compose.yml
+++ b/forgejo-runner/docker-compose.yml
@@ -42,7 +42,7 @@ services:
   forgejo-runner:
     image: code.forgejo.org/forgejo/runner:12.6.3
     container_name: forgejo-runner
-    command: daemon
+    command: /bin/forgejo-runner daemon
     restart: unless-stopped
     user: "1000:1000"  # Runner user (match host user)
     tty: false


### PR DESCRIPTION
## Summary

- **forgejo-runner restart loop:** Container was exiting immediately because no subcommand was given -- it just printed help. Added `command: daemon`.
- **beszel-agent:** Added monitoring sidecar following the same hardened config as operator. Requires `BESZEL_AGENT_KEY` in `.env`.

## Changes

- `forgejo-runner/docker-compose.yml` — added `command: daemon`, added beszel-agent service

## Test Plan

- [ ] Verify forgejo-runner stays running and registers with Forgejo
- [ ] Verify beszel-agent reports to hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)