### PR TITLE
Add MaxAdvertisedBandwidth to prevent Tor relay CPU overload

### DIFF
--- a/operator/torrc
+++ b/operator/torrc
@@ -32,9 +32,16 @@ Nickname YourRelayNickname
 ContactInfo your-email@example.com
 
 # Bandwidth limits
-# 1000 KB/s = ~1 MB/s sustained, 1500 KB/s = ~1.5 MB/s bursts
-RelayBandwidthRate 1000 KBytes
-RelayBandwidthBurst 1500 KBytes
+# 3000 KB/s = ~3 MB/s sustained, 4000 KB/s = ~4 MB/s bursts
+# Tested stable on Orange Pi 3B (ARM CPU: 14-27% CPU at 3 MB/s)
+RelayBandwidthRate 3000 KBytes
+RelayBandwidthBurst 4000 KBytes
+
+# Limit advertised bandwidth to prevent CPU overload (Orange Pi 3B ARM CPU)
+# Circuit creation is CPU-intensive; MaxAdvertised prevents request overload
+# Without this: 5 MB/s caused 55% CPU and tens of thousands of warnings
+# With 3 MB/s: CPU stays at 14-27% with zero circuit creation warnings
+MaxAdvertisedBandwidth 3000 KBytes
 
 # Exit policy: Middle relay / Guard node (no exit traffic)
 ExitPolicy reject *:*


### PR DESCRIPTION
## Summary
Adds `MaxAdvertisedBandwidth 3000 KBytes` to the Tor relay configuration to prevent CPU overload on the Orange Pi 3B ARM processor.

## Problem
The Tor relay on operator was experiencing severe CPU overload:
- **CPU usage**: 55% (sustained)
- **Warnings**: Tens of thousands of circuit creation warnings per hour
- **Error message**: `[WARN] Your computer is too slow to handle this many circuit creation requests!`
- **Root cause**: Relay running at 5 MB/s without `MaxAdvertisedBandwidth`, and ARM CPU couldn't handle the cryptographic operations

## Solution
Added `MaxAdvertisedBandwidth` directive to limit what the relay advertises to the Tor network, reducing circuit creation request load.

## Testing Results
Incremental testing to find sustainable bandwidth:

| MaxAdvertisedBandwidth | CPU Usage | Warnings | Status |
|------------------------|-----------|----------|--------|
| None (5 MB/s)          | 55%       | Thousands | ❌ Failed |
| 1000 KBytes (1 MB/s)   | 12-18%    | Zero     | ✅ Stable (15 min) |
| 2000 KBytes (2 MB/s)   | 8-19%     | Zero     | ✅ Stable (10 min) |
| 3000 KBytes (3 MB/s)   | 14-27%    | Zero     | ✅ Stable (10 min) |
| 4000 KBytes (4 MB/s)   | 12.48%    | Zero     | ✅ Stable (19 hours) |

## Final Configuration (Conservative)
```
RelayBandwidthRate 3000 KBytes      # ~3 MB/s sustained
RelayBandwidthBurst 4000 KBytes     # ~4 MB/s bursts
MaxAdvertisedBandwidth 3000 KBytes  # Limits circuit creation requests
```

Chose **3000 KBytes** over 4000 KBytes for:
- Safe headroom as relay builds reputation in Tor network
- Estimated ~33% CPU at full load (vs 55% at 5 MB/s)
- Conservative approach that's still 3x the original 1 MB/s config

## Changes
- Updated `operator/torrc`:
  - Increased `RelayBandwidthRate` from 1000 → 3000 KBytes
  - Increased `RelayBandwidthBurst` from 1500 → 4000 KBytes
  - Added `MaxAdvertisedBandwidth 3000 KBytes`
  - Updated comments with testing results and rationale

## Deployment Status
- ✅ Configuration deployed to operator server (192.168.9.10)
- ✅ Tor relay restarted and bootstrapped to 100%
- ✅ Currently running with new settings

## Technical Background
**Why MaxAdvertisedBandwidth matters:**
- Circuit creation involves CPU-intensive cryptographic operations (RSA/AES)
- ARM CPUs (Orange Pi 3B) are slower at crypto than x86
- `MaxAdvertisedBandwidth` tells Tor directory authorities the relay's capacity
- Lower advertised bandwidth = fewer circuit creation requests = lower CPU load
- Still allows relay to handle traffic bursts up to `RelayBandwidthRate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)