### PR TITLE
feat: add tdarr service with mobile 720p H265 NVENC flow reference

### DIFF
--- a/borg/paperless/tdarr/.env.example
+++ b/borg/paperless/tdarr/.env.example
@@ -6,7 +6,8 @@
 # Table: flowsjsondb, id: uL2uo5n4E
 #
 # To restore this flow after a fresh install, run on Borg:
-#   sudo sqlite3 <db_path> "INSERT OR REPLACE INTO flowsjsondb (id, json_data) VALUES ('uL2uo5n4E', '<json>');"
+#   NEW_FLOW=$(cat tdarr-flow-backup.json)
+#   sudo sqlite3 <db_path> "INSERT OR REPLACE INTO flowsjsondb (id, json_data) VALUES ('uL2uo5n4E', '$NEW_FLOW');"
 #
 # ─── Mobile 720p H265 NVENC Flow ────────────────────────────────────────────
 # Name: Mobile 720p H265 NVENC
@@ -18,18 +19,22 @@
 #   Input File
 #     → Already H.265? (checkVideoCodec: hevc)
 #         [yes] → Already 720p or less? (checkVideoResolution: height lte 720)
-#                    [yes] → (no action - already done)
-#                    [no]  → FFmpeg Start → (encode pipeline)
-#         [no]  → FFmpeg Start → (encode pipeline)
+#                    [yes] → (no action - already optimal)
+#                    [no]  → FFmpeg pipeline (downscale to 720p)
+#         [no]  → FFmpeg pipeline (re-encode to H.265)
 #
-#   Encode pipeline:
+#   FFmpeg pipeline:
 #     FFmpeg Start
 #       → Set Resolution 720p        (ffmpegCommandSetVdeoResolution: 720p)
-#       → Set Encoder NVENC          (ffmpegCommandSetVideoEncoder: hevc, hardwareType: nvenc)
-#       → Set Video Bitrate 2Mbps    (ffmpegCommandSetVideoBitrate: 2000 kbps)
+#       → Set Encoder NVENC          (ffmpegCommandSetVideoEncoder: hevc, nvenc)
+#       → Set Video Bitrate 2Mbps    (ffmpegCommandSetVideoBitrate: 2000 kbps, cbr)
 #       → Set Audio AAC 128k         (ffmpegCommandCustomArguments: outputArguments: -c:a aac -b:a 128k)
 #       → Set Container MKV          (ffmpegCommandSetContainer: mkv)
 #       → Execute FFmpeg
 #       → Sanity Check Duration      (compareFileDurationRatio: 0.98)
+#       → Replace Original File      (replaceOriginalFile)
 #
-# Node: MainNode (GTX 1660), transcodegpu workers: 2
+# Node: MainNode (GTX 1660 Super), transcodegpu workers: 2
+#
+# ─── Full Flow JSON (last updated 2026-03-29) ───────────────────────────────
+# {"_id":"uL2uo5n4E","name":"Mobile 720p H265 NVENC","description":"Mobile 720p H265 NVENC","tags":"","flowPlugins":[{"name":"Input File","sourceRepo":"Community","pluginName":"inputFile","version":"1.0.0","inputsDB":{},"fpEnabled":true,"id":"node_start","position":{"x":0,"y":300}},{"name":"Already H.265?","sourceRepo":"Community","pluginName":"checkVideoCodec","version":"1.0.0","inputsDB":{"codec":"hevc"},"fpEnabled":true,"id":"node_check_codec","position":{"x":300,"y":300}},{"name":"Already 720p or less?","sourceRepo":"Community","pluginName":"checkVideoResolution","version":"1.0.0","inputsDB":{"height":"720","condition":"lte"},"fpEnabled":true,"id":"node_check_res","position":{"x":600,"y":150}},{"name":"FFmpeg Start","sourceRepo":"Community","pluginName":"ffmpegCommandStart","version":"1.0.0","inputsDB":{"overallInputArguments":"","overallOuputArguments":""},"fpEnabled":true,"id":"node_ffmpeg_start","position":{"x":600,"y":450}},{"name":"Set Resolution 720p","sourceRepo":"Community","pluginName":"ffmpegCommandSetVdeoResolution","version":"1.0.0","inputsDB":{"targetResolution":"720p"},"fpEnabled":true,"id":"node_resolution","position":{"x":900,"y":450}},{"name":"Set Encoder NVENC","sourceRepo":"Community","pluginName":"ffmpegCommandSetVideoEncoder","version":"1.0.0","inputsDB":{"outputCodec":"hevc","ffmpegPresetEnabled":"false","hardwareDecoding":"false","hardwareType":"nvenc"},"fpEnabled":true,"id":"node_encoder","position":{"x":1200,"y":450}},{"name":"Set Video Bitrate 2M","sourceRepo":"Community","pluginName":"ffmpegCommandSetVideoBitrate","version":"1.0.0","inputsDB":{"bitrate":"2000","bitrateType":"cbr"},"fpEnabled":true,"id":"node_bitrate","position":{"x":1500,"y":450}},{"name":"Set Audio AAC 128k","sourceRepo":"Community","pluginName":"ffmpegCommandCustomArguments","version":"1.0.0","inputsDB":{"inputArguments":"","outputArguments":"-c:a aac -b:a 128k"},"fpEnabled":true,"id":"node_audio","position":{"x":1800,"y":450}},{"name":"Set Container MKV","sourceRepo":"Community","pluginName":"ffmpegCommandSetContainer","version":"1.0.0","inputsDB":{"container":"mkv"},"fpEnabled":true,"id":"node_container","position":{"x":2100,"y":450}},{"name":"Execute FFmpeg","sourceRepo":"Community","pluginName":"ffmpegCommandExecute","version":"1.0.0","inputsDB":{},"fpEnabled":true,"id":"node_execute","position":{"x":2400,"y":450}},{"name":"Sanity Check Duration","sourceRepo":"Community","pluginName":"compareFileDurationRatio","version":"1.0.0","inputsDB":{"ratio":"0.98"},"fpEnabled":true,"id":"node_duration","position":{"x":2700,"y":450}},{"name":"Replace Original File","sourceRepo":"Community","pluginName":"replaceOriginalFile","version":"1.0.0","inputsDB":{},"fpEnabled":true,"id":"node_replace","position":{"x":2100,"y":450}}],"flowEdges":[{"id":"e1","source":"node_start","sourceHandle":"1","target":"node_check_codec","targetHandle":null},{"id":"e2","source":"node_check_codec","sourceHandle":"1","target":"node_check_res","targetHandle":null},{"id":"e3","source":"node_check_codec","sourceHandle":"2","target":"node_ffmpeg_start","targetHandle":null},{"id":"e4","source":"node_check_res","sourceHandle":"2","target":"node_ffmpeg_start","targetHandle":null},{"id":"e5","source":"node_ffmpeg_start","sourceHandle":"1","target":"node_resolution","targetHandle":null},{"id":"e6","source":"node_resolution","sourceHandle":"1","target":"node_encoder","targetHandle":null},{"id":"e7","source":"node_encoder","sourceHandle":"1","target":"node_bitrate","targetHandle":null},{"id":"e8","source":"node_bitrate","sourceHandle":"1","target":"node_audio","targetHandle":null},{"id":"e9","source":"node_audio","sourceHandle":"1","target":"node_container","targetHandle":null},{"id":"e10","source":"node_container","sourceHandle":"1","target":"node_execute","targetHandle":null},{"id":"e11","source":"node_execute","sourceHandle":"1","target":"node_duration","targetHandle":null},{"id":"e9","source":"node_duration","sourceHandle":"1","target":"node_replace","targetHandle":null}],"isUiLocked":false}

--- a/borg/paperless/tdarr/.env.example
+++ b/borg/paperless/tdarr/.env.example
@@ -1,0 +1,35 @@
+# Tdarr - Automated media transcoding
+# No runtime secrets required - Tdarr has no auth by default on the local network.
+#
+# Flows are stored in the Tdarr SQLite database (not configurable via env).
+# DB path: /mnt/disks/appdataAndDocker/appdata/tdarr-server/server/Tdarr/DB2/SQL/database.db
+# Table: flowsjsondb, id: uL2uo5n4E
+#
+# To restore this flow after a fresh install, run on Borg:
+#   sudo sqlite3 <db_path> "INSERT OR REPLACE INTO flowsjsondb (id, json_data) VALUES ('uL2uo5n4E', '<json>');"
+#
+# ─── Mobile 720p H265 NVENC Flow ────────────────────────────────────────────
+# Name: Mobile 720p H265 NVENC
+# Purpose: Transcode media to 720p HEVC for offline mobile viewing (plane trips etc.)
+# Library: Mobile Media → /mnt/user/media-mobile/
+# Output: 720p, hevc_nvenc, 2Mbps video, AAC 128k audio, MKV container
+#
+# Flow logic:
+#   Input File
+#     → Already H.265? (checkVideoCodec: hevc)
+#         [yes] → Already 720p or less? (checkVideoResolution: height lte 720)
+#                    [yes] → (no action - already done)
+#                    [no]  → FFmpeg Start → (encode pipeline)
+#         [no]  → FFmpeg Start → (encode pipeline)
+#
+#   Encode pipeline:
+#     FFmpeg Start
+#       → Set Resolution 720p        (ffmpegCommandSetVdeoResolution: 720p)
+#       → Set Encoder NVENC          (ffmpegCommandSetVideoEncoder: hevc, hardwareType: nvenc)
+#       → Set Video Bitrate 2Mbps    (ffmpegCommandSetVideoBitrate: 2000 kbps)
+#       → Set Audio AAC 128k         (ffmpegCommandCustomArguments: outputArguments: -c:a aac -b:a 128k)
+#       → Set Container MKV          (ffmpegCommandSetContainer: mkv)
+#       → Execute FFmpeg
+#       → Sanity Check Duration      (compareFileDurationRatio: 0.98)
+#
+# Node: MainNode (GTX 1660), transcodegpu workers: 2


### PR DESCRIPTION
## Summary
- Adds `borg/paperless/tdarr/.env.example` documenting the Tdarr service configuration
- Documents the Mobile 720p H265 NVENC transcoding flow (stored in Tdarr's SQLite DB, not in env)
- Includes full flow JSON schema and DB restore instructions for disaster recovery

## Context
Tdarr flows cannot be driven from env vars — they live in the SQLite database at `/mnt/disks/appdataAndDocker/appdata/tdarr-server/server/Tdarr/DB2/SQL/database.db`. This file documents the flow for reference and provides restore instructions.

The flow transcodes the mobile Plex library (`/media-mobile`) to 720p H265 via NVENC at 2Mbps / AAC 128k for use on the Kenya/Bangkok trip.

## Test Plan
- [ ] Verify tdarr container picks up existing appdata volume on deploy
- [ ] Confirm flow exists in Tdarr UI under "Mobile 720p H265 NVENC"
- [ ] Queue a file and verify GPU utilization via `nvidia-smi`

🤖 Generated with [Claude Code](https://claude.com/claude-code)