### PR TITLE
Set OLLAMA_KEEP_ALIVE=0 on paperless-ollama

### DIFF
--- a/borg/paperless/docker-compose.yml
+++ b/borg/paperless/docker-compose.yml
@@ -111,7 +111,6 @@ services:
       net.unraid.docker.webui: "http://[IP]:[PORT:11434]/"
     environment:
       TZ: America/Chicago
-      OLLAMA_KEEP_ALIVE: "0"
     env_file:
       - /mnt/disks/appdataAndDocker/appdata/paperless-ollama/ollama.env
     volumes:

--- a/borg/paperless/docker-compose.yml
+++ b/borg/paperless/docker-compose.yml
@@ -111,6 +111,7 @@ services:
       net.unraid.docker.webui: "http://[IP]:[PORT:11434]/"
     environment:
       TZ: America/Chicago
+      OLLAMA_KEEP_ALIVE: "0"
     env_file:
       - /mnt/disks/appdataAndDocker/appdata/paperless-ollama/ollama.env
     volumes:

--- a/borg/paperless/ollama/.env.example
+++ b/borg/paperless/ollama/.env.example
@@ -1,5 +1,5 @@
 TZ=America/New_York
-OLLAMA_KEEP_ALIVE=15m
+OLLAMA_KEEP_ALIVE=0
 NVIDIA_DRIVER_CAPABILITIES=all # comment out if you aren't using NVIDIA GPUs
 NVIDIA_VISIBLE_DEVICES=GPU-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx # set to your GPU ID (use 'all' for all GPUs)
 OLLAMA_HOST=0.0.0.0:11434


### PR DESCRIPTION
## Summary
- Add `OLLAMA_KEEP_ALIVE=0` to `paperless-ollama` so models unload immediately after each job
- Without this, `qwen2.5vl:7b` stays resident after paperless-gpt processes a doc, pegging CPU at ~1000% and blocking all other Ollama requests (including Open WebUI)

## Test plan
- [ ] Redeploy paperless-ollama on Borg
- [ ] Process a document through paperless-gpt
- [ ] Verify `ollama ps` shows no model loaded after the job completes
- [ ] Verify CPU returns to idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)