### PR TITLE
Add Forgejo CI: yaml-lint and secrets scan

### DIFF
--- a/.forgejo/workflows/validate.yml
+++ b/.forgejo/workflows/validate.yml
@@ -1,0 +1,40 @@
+name: Validate
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  yaml-lint:
+    name: Lint docker-compose files
+    runs-on: linux
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install yamllint
+        run: pip3 install yamllint --quiet
+
+      - name: Lint all docker-compose.yml files
+        run: |
+          find . -name "docker-compose.yml" | sort | while read f; do
+            echo "Checking $f..."
+            yamllint -d '{extends: default, rules: {line-length: disable, comments: disable, truthy: disable}}' "$f" || exit 1
+          done
+          echo "All compose files passed."
+
+  secrets-scan:
+    name: Scan for secrets
+    runs-on: linux
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Gitleaks
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/repo" \
+            ghcr.io/gitleaks/gitleaks:latest \
+            detect --source /repo --verbose --no-git


### PR DESCRIPTION
## Summary
- **yamllint**: validates all `docker-compose.yml` files across the repo for YAML syntax errors on every push/PR
- **Gitleaks**: scans for accidentally committed secrets (API tokens, passwords, etc.)
- Runs on the Orange Pi arm64 runner (`runs-on: linux`)

## Why yamllint instead of `docker compose config`?
The compose files use absolute `env_file` paths (`/mnt/disks/appdataAndDocker/...`) that don't exist on the runner, which would make `docker compose config` fail in CI. yamllint catches YAML syntax and structure errors without needing real env files.

## Test plan
- [ ] Verify both jobs pass on the Orange Pi runner
- [ ] Confirm Gitleaks doesn't false-positive on any `.env.example` placeholder values

🤖 Generated with [Claude Code](https://claude.com/claude-code)