### PR TITLE
fix: rename TOR_CONTACT_INFO to TOR_CONTACT in operator .env.example

### DIFF
--- a/operator/.env.example
+++ b/operator/.env.example
@@ -7,7 +7,7 @@ BESZEL_AGENT_KEY=your-ssh-public-key-here
 
 # Tor Relay Identity (required)
 TOR_NICKNAME=YourRelayNickname
-TOR_CONTACT_INFO=your-email@example.com
+TOR_CONTACT=your-email@example.com
 
 # Tor Relay Ports (optional - defaults shown)
 #TOR_OR_PORT=8443


### PR DESCRIPTION
## Summary

- `TOR_CONTACT_INFO` in `operator/.env.example` was misnamed — the `tor-relay-docker` entrypoint (see tor-relay-docker PR #9) reads `TOR_CONTACT`, so `TOR_CONTACT_INFO` was silently ignored
- Renamed to `TOR_CONTACT` to match

## Action required after merging tor-relay-docker PR #9

If your live `.env` on the operator machine has `TOR_CONTACT_INFO=...`, rename it to `TOR_CONTACT=...` and redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)